### PR TITLE
11: updates for new frontend routes

### DIFF
--- a/routes/controllers/groups.controller.js
+++ b/routes/controllers/groups.controller.js
@@ -12,7 +12,7 @@ const groupNameIsReserved = (groupName) => {
 function createGroupLink(group, competitionID) {
   return (
     url +
-    "/predictions?type=groupLink&groupID=" +
+    "/competitions?type=groupLink&groupID=" +
     group._id +
     "&groupPasscode=" +
     group.passcode +

--- a/routes/controllers/prediction.controller.js
+++ b/routes/controllers/prediction.controller.js
@@ -363,11 +363,11 @@ async function addPredictionToGroup(req, res, next) {
       status: 404,
       message: "This prediction is already a member of the requested group",
     });
-  const result = await Prediction.updateOne(
+  await Prediction.updateOne(
     { _id: req.params.id },
     { $push: { groups: group._id } }
   );
-  res.send(result);
+  res.send(group._id);
 }
 
 async function removePredictionFromGroup(req, res, next) {


### PR DESCRIPTION
- update link address to new `competitions` route when getting a group link
- send back group ID when adding prediction to group