### PR TITLE
hotfix: allow access to get result route unauthed

### DIFF
--- a/__test__/integration/routes/result.route.test.js
+++ b/__test__/integration/routes/result.route.test.js
@@ -138,7 +138,7 @@ describe("resultsRoute", () => {
         .get(endpoint + "/" + id)
         .set(header, token);
     };
-    testAuth(exec);
+
     testObjectID(exec, true);
     it("should return 404 if the competition is not found", async () => {
       const res = await exec(getToken(), mongoose.Types.ObjectId());

--- a/routes/routers/result.route.js
+++ b/routes/routers/result.route.js
@@ -9,10 +9,8 @@ const {
   calculateCompetition,
 } = require("../controllers/result.controller");
 
-router.use(auth);
-
-router.put("/:code", [adminCheck], updateResultsByCompetition);
+router.put("/:code", [auth, adminCheck], updateResultsByCompetition);
 router.get("/:id", [validateObjectID], getResult);
-router.post("/calculate/:code", [adminCheck], calculateCompetition);
+router.post("/calculate/:code", [auth, adminCheck], calculateCompetition);
 
 module.exports = router;


### PR DESCRIPTION
allow access to get result route unauthed for second chance competitions