### PR TITLE
refactor calculatePotentialPoints to use binary bracket tree

### DIFF
--- a/__test__/unit/utils/calculations.test.js
+++ b/__test__/unit/utils/calculations.test.js
@@ -1,6 +1,8 @@
+const potentialPointsTestCases = require("../../../test_data/potentialPointsCases");
 const {
   calculatePrediction,
   addRanking,
+  buildBracketTree,
 } = require("../../../utils/calculations");
 const {
   predictions,
@@ -28,7 +30,15 @@ describe("calculations", () => {
       },
     };
     const exec = (prediction, result, competition, matches) => {
-      return calculatePrediction(prediction, result, competition, matches);
+      let tree = null;
+      let final = null;
+      if (matches && matches.length > 0) {
+        matches.forEach((match) => {
+          if (!final || match.round > final.round) final = match;
+        });
+        if (final) tree = buildBracketTree(final.matchNumber, matches);
+      }
+      return calculatePrediction(prediction, result, competition, tree, final);
     };
 
     const setPrediction = (
@@ -36,7 +46,7 @@ describe("calculations", () => {
       groupResult,
       playoffResult,
       miscResult,
-      groupMatrixResult
+      groupMatrixResult,
     ) => {
       let prediction = { ...predictions[0] };
       if (matchLevel.includes("group") || matchLevel.includes("groupMatrix")) {
@@ -142,10 +152,10 @@ describe("calculations", () => {
         // should get 16 for third place pick, 10 each for discipline and topScorer
         expect(res.points.misc.points).toBe(36);
         expect(res.totalPoints).toBe(
-          res.points.champion.points + res.points.misc.points
+          res.points.champion.points + res.points.misc.points,
         );
         expect(res.totalPicks).toBe(
-          res.points.champion.correctPicks + res.points.misc.correctPicks
+          res.points.champion.correctPicks + res.points.misc.correctPicks,
         );
       });
       it("should calculate the entire prediction correctly", () => {
@@ -168,13 +178,13 @@ describe("calculations", () => {
           res.points.group.points +
             res.points.playoff.points +
             res.points.champion.points +
-            res.points.misc.points
+            res.points.misc.points,
         );
         expect(res.totalPicks).toBe(
           res.points.group.correctPicks +
             res.points.playoff.correctPicks +
             res.points.champion.correctPicks +
-            res.points.misc.correctPicks
+            res.points.misc.correctPicks,
         );
       });
     });
@@ -186,7 +196,7 @@ describe("calculations", () => {
           [
             { groupName: "a", teamOrder: ["b", "a", "c", "d"] },
             { groupName: "b", teamOrder: ["f", "g", "f", "g"] },
-          ]
+          ],
         );
         const res = exec(prediction, result, competitions[0]);
 
@@ -255,7 +265,7 @@ describe("calculations", () => {
             thirdPlace: "c",
             discipline: "a",
             topScorer: "a",
-          }
+          },
         );
         const res = exec(prediction, result, competitions[0]);
 
@@ -307,7 +317,7 @@ describe("calculations", () => {
         const res = exec(prediction, result, competition);
 
         const matrixPrediction = prediction.groupPredictions.find(
-          (g) => g.groupName === competition.groupMatrix[0].key
+          (g) => g.groupName === competition.groupMatrix[0].key,
         );
 
         const regularGroupPoints =
@@ -323,7 +333,7 @@ describe("calculations", () => {
           competition.groupMatrix[0].scoring.bonus;
 
         expect(res.points.group.points).toBe(
-          regularGroupPoints + matrixGroupPoints
+          regularGroupPoints + matrixGroupPoints,
         );
         expect(res.points.group.correctPicks).toBe(11);
         expect(res.points.playoff.points).toBe(
@@ -331,24 +341,24 @@ describe("calculations", () => {
             4 +
             competition.scoring.playoff.find((p) => p.roundNumber === 2)
               .points *
-              2
+              2,
         );
         expect(res.points.playoff.correctPicks).toBe(6);
         expect(res.points.champion.points).toBe(competition.scoring.champion);
         expect(res.points.misc.points).toBe(
-          competition.miscPicks.reduce((prev, cur) => prev + cur.points, 0)
+          competition.miscPicks.reduce((prev, cur) => prev + cur.points, 0),
         );
         expect(res.totalPoints).toBe(
           res.points.group.points +
             res.points.playoff.points +
             res.points.champion.points +
-            res.points.misc.points
+            res.points.misc.points,
         );
         expect(res.totalPicks).toBe(
           res.points.group.correctPicks +
             res.points.playoff.correctPicks +
             res.points.champion.correctPicks +
-            res.points.misc.correctPicks
+            res.points.misc.correctPicks,
         );
       });
     });
@@ -362,7 +372,7 @@ describe("calculations", () => {
           [
             { groupName: "a", teamOrder: ["a", "a", "a", "a"] },
             { groupName: "b", teamOrder: ["e", "e", "e", "e"] },
-          ]
+          ],
         );
         const res = exec(prediction, result, competitions[0]);
 
@@ -386,132 +396,22 @@ describe("calculations", () => {
       });
     });
     describe("adding potential points", () => {
-      const resultForPotentialPoints = {
-        code: "worldCup2022",
-        group: [
-          {
-            groupName: "A",
-            teamOrder: ["a", "b", "c", "d"],
-          },
-        ],
-        playoff: [
-          {
-            round: 1,
-            teams: ["a", "b", "c", "d"],
-            points: 2,
-          },
-        ],
-        misc: {
-          winner: "",
-          thirdPlace: "",
-          discipline: "",
-          topScorer: "",
-        },
-        potentials: {
-          realisticWinners: {
-            topScorer: ["a", "c"],
-            discipline: ["d"],
-            thirdPlace: ["a", "b"],
-          },
-        },
-      };
-      test("potential points possible should match the total points when the tournament is finished", () => {
-        const prediction = setPrediction(["playoff"], null, [
-          { matchNumber: 1, homeTeam: "a", awayTeam: "b", round: 1 },
-          { matchNumber: 1, homeTeam: "c", awayTeam: "d", round: 1 },
-          { matchNumber: 1, homeTeam: "a", awayTeam: "c", round: 4 },
-        ]);
-        const res = exec(prediction, resultForPotentialPoints, competitions[0]);
-        expect(res.totalPoints).toBe(res.potentialPoints.maximum);
-      });
-      test("potential points should be able to calculate if the winner is possible and assign those points to realistic and maximum", () => {
-        const prediction = setPrediction(
-          ["playoff", "misc"],
-          null,
-          [
-            { matchNumber: 1, homeTeam: "a", awayTeam: "b", round: 1 },
-            { matchNumber: 1, homeTeam: "c", awayTeam: "d", round: 1 },
-            { matchNumber: 1, homeTeam: "a", awayTeam: "c", round: 2 },
-          ],
-          {
-            winner: "a",
-          }
-        );
-        const res = exec(prediction, resultForPotentialPoints, competitions[0]);
-        expect(res.potentialPoints.maximum).toBe(res.potentialPoints.realistic);
-        expect(res.potentialPoints.maximum).toBe(
-          res.totalPoints + competitions[0].scoring.champion
-        );
-      });
-      test("potential points should calculate the difference between realistic and maximum points for miscPicks", () => {
-        const prediction = setPrediction(
-          ["playoff", "misc"],
-          null,
-          [
-            { matchNumber: 1, homeTeam: "a", awayTeam: "b", round: 1 },
-            { matchNumber: 1, homeTeam: "c", awayTeam: "d", round: 1 },
-            { matchNumber: 1, homeTeam: "a", awayTeam: "c", round: 2 },
-          ],
-          {
-            topScorer: "b",
-            discipline: "b",
-            thirdPlace: "c",
-          }
-        );
-        const res = exec(prediction, resultForPotentialPoints, competitions[0]);
-        expect(res.potentialPoints.maximum).not.toBe(
-          res.potentialPoints.realistic
-        );
-        expect(res.potentialPoints.realistic).toBe(res.totalPoints);
-        expect(res.potentialPoints.maximum).toBe(
-          res.totalPoints +
-            competitions[0].miscPicks.find((mp) => mp.name === "topScorer")
-              .points +
-            competitions[0].miscPicks.find((mp) => mp.name === "discipline")
-              .points
-        );
-      });
-      test("potential points should calculate the rounds in reverse to accurately represent available points when teams picked in next round paly against each other", () => {
-        const prediction = setPrediction(["playoff"], null, [
-          { matchNumber: 1, homeTeam: "a", awayTeam: "b", round: 1 },
-          { matchNumber: 2, homeTeam: "c", awayTeam: "d", round: 1 },
-          { matchNumber: 3, homeTeam: "c", awayTeam: "d", round: 2 },
-        ]);
-        const matches = [
-          {
-            matchNumber: 1,
-            homeTeamName: "a",
-            awayTeamName: "b",
-            round: 1,
-          },
-          {
-            matchNumber: 2,
-            homeTeamName: "c",
-            awayTeamName: "d",
-            round: 1,
-          },
-          {
-            matchNumber: 3,
-            homeTeamName: "Winner 1",
-            awayTeamName: "Winner 2",
-            round: 2,
-            getTeamsFrom: {
-              home: { matchNumber: 1 },
-              away: { matchNumber: 2 },
-            },
-          },
-        ];
-        const res = exec(
-          prediction,
-          resultForPotentialPoints,
-          competitions[0],
-          matches
-        );
-        expect(res.potentialPoints.maximum).toBe(
-          res.totalPoints +
-            competitions[0].scoring.playoff.find((s) => s.roundNumber === 2)
-              .points
-        );
+      potentialPointsTestCases.forEach((testCase) => {
+        test(testCase.description, () => {
+          const res = exec(
+            testCase.data.prediction,
+            testCase.data.result,
+            testCase.data.competition,
+            testCase.data.matches,
+          );
+          expect(res.totalPoints).toBe(testCase.expected.totalPoints);
+          expect(res.potentialPoints.maximum).toBe(
+            testCase.expected.potentialPoints.maximum,
+          );
+          expect(res.potentialPoints.realistic).toBe(
+            testCase.expected.potentialPoints.realistic,
+          );
+        });
       });
     });
 
@@ -522,7 +422,7 @@ describe("calculations", () => {
           [
             { groupName: "a", teamOrder: ["b", "a", "c", "d"] },
             { groupName: "b", teamOrder: ["f", "g", "f", "g"] },
-          ]
+          ],
         );
         prediction.isSecondChance = true;
         const res = exec(prediction, result, competitions[0]);
@@ -570,6 +470,67 @@ describe("calculations", () => {
         expect(res.points.champion.points).toBe(32);
         expect(res.points.champion.correctPicks).toBe(1);
       });
+    });
+  });
+
+  describe("buildBracketTree", () => {
+    const matches = [
+      { matchNumber: 1, homeTeamName: "A", awayTeamName: "B", round: 1 },
+      { matchNumber: 2, homeTeamName: "C", awayTeamName: "D", round: 1 },
+      {
+        matchNumber: 3,
+        homeTeamName: "Winner 1",
+        awayTeamName: "Winner 2",
+        round: 2,
+        getTeamsFrom: { home: { matchNumber: 1 }, away: { matchNumber: 2 } },
+      },
+    ];
+
+    it("should return null for an unknown match number", () => {
+      expect(buildBracketTree(99, matches)).toBeNull();
+    });
+    it("should return a leaf node with no children for a match without getTeamsFrom", () => {
+      const tree = buildBracketTree(1, matches);
+      expect(tree.match.matchNumber).toBe(1);
+      expect(tree.left).toBeUndefined();
+      expect(tree.right).toBeUndefined();
+    });
+    it("should set left and right children from getTeamsFrom", () => {
+      const tree = buildBracketTree(3, matches);
+      expect(tree.match.matchNumber).toBe(3);
+      expect(tree.left.match.matchNumber).toBe(1);
+      expect(tree.right.match.matchNumber).toBe(2);
+    });
+    it("should recursively build a multi-level tree", () => {
+      const deepMatches = [
+        { matchNumber: 1, homeTeamName: "A", awayTeamName: "B", round: 1 },
+        { matchNumber: 2, homeTeamName: "C", awayTeamName: "D", round: 1 },
+        { matchNumber: 3, homeTeamName: "E", awayTeamName: "F", round: 1 },
+        { matchNumber: 4, homeTeamName: "G", awayTeamName: "H", round: 1 },
+        {
+          matchNumber: 5,
+          round: 2,
+          getTeamsFrom: { home: { matchNumber: 1 }, away: { matchNumber: 2 } },
+        },
+        {
+          matchNumber: 6,
+          round: 2,
+          getTeamsFrom: { home: { matchNumber: 3 }, away: { matchNumber: 4 } },
+        },
+        {
+          matchNumber: 7,
+          round: 3,
+          getTeamsFrom: { home: { matchNumber: 5 }, away: { matchNumber: 6 } },
+        },
+      ];
+      const tree = buildBracketTree(7, deepMatches);
+      expect(tree.match.matchNumber).toBe(7);
+      expect(tree.left.match.matchNumber).toBe(5);
+      expect(tree.right.match.matchNumber).toBe(6);
+      expect(tree.left.left.match.matchNumber).toBe(1);
+      expect(tree.left.right.match.matchNumber).toBe(2);
+      expect(tree.right.left.match.matchNumber).toBe(3);
+      expect(tree.right.right.match.matchNumber).toBe(4);
     });
   });
 
@@ -815,7 +776,7 @@ describe("calculations", () => {
             res.forEach((r) => {
               expect(r.ranking).toBe(r.expectedRanking);
             });
-          }
+          },
         );
       });
     });

--- a/routes/controllers/leaderboard.controller.js
+++ b/routes/controllers/leaderboard.controller.js
@@ -75,6 +75,7 @@ async function searchLeaderboard(req, res, next) {
     totalPoints: "$totalPoints",
     totalPicks: "$totalPicks",
     ranking: "$ranking",
+    potentialPoints: "$potentialPoints",
   };
   if (deadlineHasPassed(competition, req.query.secondChance === "true"))
     projectedFields.misc = "$misc";

--- a/routes/controllers/result.controller.js
+++ b/routes/controllers/result.controller.js
@@ -1,5 +1,5 @@
 const mongoose = require("mongoose");
-const { calculatePrediction, addRanking } = require("../../utils/calculations");
+const { calculatePrediction, addRanking, buildBracketTree } = require("../../utils/calculations");
 
 const { Result, validateResult } = require("../../models/result.model");
 const { Prediction } = require("../../models/prediction.model");
@@ -11,10 +11,19 @@ const calculateAndPostSubmissions = async (competition, result) => {
     competitionID: competition._id,
   });
   const matches = await Match.find({ bracketCode: competition.code });
+
+  // Build tree and find final once — matches are the same for all predictions
+  let tree = null;
+  let final = null;
+  matches.forEach((match) => {
+    if (!final || match.round > final.round) final = match;
+  });
+  if (final) tree = buildBracketTree(final.matchNumber, matches);
+
   let updatedPoints = [];
   allPredictions.forEach((p) => {
     const { points, totalPoints, totalPicks, potentialPoints } =
-      calculatePrediction(p, result, competition, matches);
+      calculatePrediction(p, result, competition, tree, final);
     updatedPoints.push({
       _id: p._id,
       isSecondChance: p.isSecondChance,

--- a/test_data/potentialPointsCases.js
+++ b/test_data/potentialPointsCases.js
@@ -1,0 +1,322 @@
+const defaultCompetition = {
+  scoring: {
+    playoff: [
+      { roundNumber: 1, points: 2 },
+      { roundNumber: 2, points: 4 },
+      { roundNumber: 3, points: 8 },
+      { roundNumber: 4, points: 16 },
+    ],
+    champion: 32,
+  },
+  miscPicks: [
+    { name: "thirdPlace", points: 16 },
+    { name: "discipline", points: 10 },
+    { name: "topScorer", points: 10 },
+  ],
+  groupMatrix: [{ key: "thirdPlaceRank" }],
+};
+
+const defaultResult = {
+  group: [{ groupName: "A", teamOrder: ["a", "b", "c", "d"] }],
+  playoff: [{ round: 1, teams: ["a", "b", "c", "d"], points: 2 }],
+  misc: { winner: "", thirdPlace: "", discipline: "", topScorer: "" },
+  potentials: {
+    realisticWinners: {
+      topScorer: ["a", "c"],
+      discipline: ["d"],
+    },
+  },
+};
+
+// Two-match bracket feeding into a final at round 2
+const defaultMatches = [
+  { matchNumber: 1, homeTeamName: "a", awayTeamName: "b", round: 1 },
+  { matchNumber: 2, homeTeamName: "c", awayTeamName: "d", round: 1 },
+  {
+    matchNumber: 3,
+    homeTeamName: "Winner 1",
+    awayTeamName: "Winner 2",
+    round: 2,
+    getTeamsFrom: {
+      home: { matchNumber: 1 },
+      away: { matchNumber: 2 },
+    },
+  },
+];
+
+// 3-round bracket with 8 QF teams: QF(r1) → SF(r2) → Final(r3)
+// SF match 5 is fed by QF matches 1 (A/B) and 2 (C/D)
+// SF match 6 is fed by QF matches 3 (E/F) and 4 (G/H)
+const qfResult = {
+  playoff: [{ round: 1, teams: ["A", "B", "C", "D", "E", "F", "G", "H"] }],
+  misc: {},
+};
+const qfCompetition = {
+  scoring: {
+    playoff: [
+      { roundNumber: 1, points: 2 },
+      { roundNumber: 2, points: 4 },
+      { roundNumber: 3, points: 8 },
+    ],
+  },
+};
+const qfMatches = [
+  { matchNumber: 1, homeTeamName: "A", awayTeamName: "B", round: 1 },
+  { matchNumber: 2, homeTeamName: "C", awayTeamName: "D", round: 1 },
+  { matchNumber: 3, homeTeamName: "E", awayTeamName: "F", round: 1 },
+  { matchNumber: 4, homeTeamName: "G", awayTeamName: "H", round: 1 },
+  {
+    matchNumber: 5,
+    homeTeamName: "Winner 1",
+    awayTeamName: "Winner 2",
+    round: 2,
+    getTeamsFrom: { home: { matchNumber: 1 }, away: { matchNumber: 2 } },
+  },
+  {
+    matchNumber: 6,
+    homeTeamName: "Winner 3",
+    awayTeamName: "Winner 4",
+    round: 2,
+    getTeamsFrom: { home: { matchNumber: 3 }, away: { matchNumber: 4 } },
+  },
+  {
+    matchNumber: 7,
+    homeTeamName: "Winner 5",
+    awayTeamName: "Winner 6",
+    round: 3,
+    getTeamsFrom: { home: { matchNumber: 5 }, away: { matchNumber: 6 } },
+  },
+];
+
+const potentialPointsTestCases = [
+  {
+    description: "No Playoff Results, do not calculate potential points",
+    data: {
+      prediction: {
+        groupPredictions: [{ groupName: "A", teamOrder: ["a", "b"] }],
+        playoffPredictions: [{ round: 1, homeTeam: "a", awayTeam: "b" }],
+      },
+      result: {
+        group: [{ groupName: "A", teamOrder: ["a", "b"] }],
+      },
+      competition: {
+        scoring: {
+          group: { perTeam: 1 },
+          playoff: [{ roundNumber: 1, points: 4 }],
+        },
+      },
+      matches: [],
+    },
+    expected: {
+      totalPoints: 2,
+      potentialPoints: { maximum: 0, realistic: 0 },
+    },
+  },
+  {
+    description: "Tournament is finished, potential points match total points",
+    data: {
+      prediction: {
+        playoffPredictions: [{ round: 1, homeTeam: "a", awayTeam: "b" }],
+      },
+      result: {
+        playoff: [{ round: 1, teams: ["a", "b"] }],
+      },
+      competition: {
+        scoring: {
+          playoff: [{ roundNumber: 1, points: 4 }],
+        },
+      },
+      matches: [],
+    },
+    expected: {
+      totalPoints: 8,
+      potentialPoints: { maximum: 8, realistic: 8 },
+    },
+  },
+  {
+    description:
+      "Potential points equal total points when no matches passed and tournament not finished",
+    data: {
+      prediction: {
+        playoffPredictions: [
+          { matchNumber: 1, homeTeam: "a", awayTeam: "b", round: 1 },
+          { matchNumber: 1, homeTeam: "c", awayTeam: "d", round: 1 },
+          { matchNumber: 1, homeTeam: "a", awayTeam: "c", round: 4 },
+        ],
+      },
+      result: defaultResult,
+      competition: defaultCompetition,
+      matches: [],
+    },
+    expected: {
+      totalPoints: 8,
+      potentialPoints: { maximum: 8, realistic: 8 },
+    },
+  },
+  {
+    description:
+      "Winner pick still in remaining teams adds champion points to both maximum and realistic",
+    data: {
+      prediction: {
+        playoffPredictions: [
+          { matchNumber: 1, homeTeam: "a", awayTeam: "b", round: 1 },
+          { matchNumber: 1, homeTeam: "c", awayTeam: "d", round: 1 },
+          { matchNumber: 1, homeTeam: "a", awayTeam: "c", round: 2 },
+        ],
+        misc: { winner: "a" },
+      },
+      result: defaultResult,
+      competition: defaultCompetition,
+      matches: [],
+    },
+    expected: {
+      totalPoints: 8,
+      potentialPoints: { maximum: 40, realistic: 40 },
+    },
+  },
+  {
+    description:
+      "MiscPicks in remaining teams add to maximum only; realisticWinners add to realistic too",
+    data: {
+      prediction: {
+        playoffPredictions: [
+          { matchNumber: 1, homeTeam: "a", awayTeam: "b", round: 1 },
+          { matchNumber: 1, homeTeam: "c", awayTeam: "d", round: 1 },
+          { matchNumber: 1, homeTeam: "a", awayTeam: "c", round: 2 },
+        ],
+        misc: { topScorer: "b", discipline: "c", thirdPlace: "c" },
+      },
+      result: defaultResult,
+      competition: defaultCompetition,
+      matches: [],
+    },
+    expected: {
+      totalPoints: 8,
+      // topScorer "b" and discipline "c" are in remainingTeams but not realisticWinners
+      potentialPoints: { maximum: 28, realistic: 8 },
+    },
+  },
+  {
+    description:
+      "ThirdPlace pick adds to both maximum and realistic if pick is a semi-finalist still remaining",
+    data: {
+      prediction: {
+        playoffPredictions: [
+          { matchNumber: 1, homeTeam: "a", awayTeam: "b", round: 1 },
+          { matchNumber: 2, homeTeam: "c", awayTeam: "d", round: 1 },
+        ],
+        misc: { thirdPlace: "b" },
+      },
+      result: defaultResult,
+      competition: defaultCompetition,
+      matches: defaultMatches,
+    },
+    expected: {
+      totalPoints: 8,
+      potentialPoints: { maximum: 24, realistic: 24 },
+    },
+  },
+  {
+    description: "ThirdPlace pick adds no points if pick is not a remaining team",
+    data: {
+      prediction: {
+        playoffPredictions: [
+          { matchNumber: 1, homeTeam: "a", awayTeam: "b", round: 1 },
+          { matchNumber: 2, homeTeam: "c", awayTeam: "d", round: 1 },
+        ],
+        misc: { thirdPlace: "z" },
+      },
+      result: defaultResult,
+      competition: defaultCompetition,
+      matches: defaultMatches,
+    },
+    expected: {
+      totalPoints: 8,
+      potentialPoints: { maximum: 8, realistic: 8 },
+    },
+  },
+  {
+    description:
+      "Predicted finalists from the same bracket half subtract one set of points (path collision)",
+    data: {
+      prediction: {
+        playoffPredictions: [
+          { matchNumber: 1, homeTeam: "a", awayTeam: "b", round: 1 },
+          { matchNumber: 2, homeTeam: "c", awayTeam: "d", round: 1 },
+          { matchNumber: 3, homeTeam: "c", awayTeam: "d", round: 2 },
+        ],
+      },
+      result: defaultResult,
+      competition: defaultCompetition,
+      matches: defaultMatches,
+    },
+    expected: {
+      totalPoints: 8,
+      // c and d are both in the right subtree — collision deducts one set of points
+      potentialPoints: { maximum: 12, realistic: 12 },
+    },
+  },
+  {
+    description:
+      "At QF stage: predicting two teams from the same QF match in the SF collides — only one set of points awarded",
+    data: {
+      prediction: {
+        // A and B both come from QF match 1 (left subtree of SF match 5)
+        playoffPredictions: [
+          { matchNumber: 5, homeTeam: "A", awayTeam: "B", round: 2 },
+        ],
+      },
+      result: qfResult,
+      competition: qfCompetition,
+      matches: qfMatches,
+    },
+    expected: {
+      totalPoints: 0,
+      // A reachable (+4) + B reachable (+4) - collision (-4) = 4
+      potentialPoints: { maximum: 4, realistic: 4 },
+    },
+  },
+  {
+    description:
+      "At QF stage: predicting two teams from different QF matches in the SF has no collision — both sets of points awarded",
+    data: {
+      prediction: {
+        // A comes from QF match 1 (left subtree), C comes from QF match 2 (right subtree)
+        playoffPredictions: [
+          { matchNumber: 5, homeTeam: "A", awayTeam: "C", round: 2 },
+        ],
+      },
+      result: qfResult,
+      competition: qfCompetition,
+      matches: qfMatches,
+    },
+    expected: {
+      totalPoints: 0,
+      // A reachable (+4) + C reachable (+4) = 8
+      potentialPoints: { maximum: 8, realistic: 8 },
+    },
+  },
+  {
+    description:
+      "At QF stage: predicting A vs C in the final collides even though they don't meet at QF — both are in SF5's subtree so only one can reach the final",
+    data: {
+      prediction: {
+        // A (match 1) and C (match 2) are in different QF matches but both feed into SF5
+        // SF5 is the left child of the final — so A and C share the same half of the bracket
+        playoffPredictions: [
+          { matchNumber: 7, homeTeam: "A", awayTeam: "C", round: 3 },
+        ],
+      },
+      result: qfResult,
+      competition: qfCompetition,
+      matches: qfMatches,
+    },
+    expected: {
+      totalPoints: 0,
+      // A reachable (+8) + C reachable (+8) - collision (-8) = 8
+      potentialPoints: { maximum: 8, realistic: 8 },
+    },
+  },
+];
+
+module.exports = potentialPointsTestCases;

--- a/test_data/testResults.json
+++ b/test_data/testResults.json
@@ -86,8 +86,7 @@
   "potentials": {
     "realisticWinners": {
       "topScorer": ["France", "Argentina"],
-      "discipline": ["Saudi Arabia", "Argentina"],
-      "thirdPlace": ["Croatia", "Argentina", "Morocco", "France"]
+      "discipline": ["Saudi Arabia", "Argentina"]
     }
   }
 }

--- a/utils/calculations.js
+++ b/utils/calculations.js
@@ -1,4 +1,4 @@
-function calculatePrediction(prediction, result, competition, matches) {
+function calculatePrediction(prediction, result, competition, tree, final) {
   let points = {
     group: { points: 0, correctPicks: 0, bonus: 0 },
     playoff: { points: 0, correctPicks: 0 },
@@ -17,7 +17,7 @@ function calculatePrediction(prediction, result, competition, matches) {
       let thisGroupCorrectPicks = 0;
       let thisGroupBonus = 0;
       const groupResult = result.group.find(
-        (groupResult) => groupResult.groupName === groupPrediction.groupName
+        (groupResult) => groupResult.groupName === groupPrediction.groupName,
       );
       if (!prediction.isSecondChance && groupResult) {
         // find if this group is part of a matrix
@@ -45,7 +45,7 @@ function calculatePrediction(prediction, result, competition, matches) {
           groupResult.teamOrder.length * scoring.perTeam
         ) {
           thisGroupBonus += 1;
-          thisGroupPoints += scoring.bonus;
+          thisGroupPoints += scoring.bonus || 0;
         }
       }
       points.group = {
@@ -56,12 +56,6 @@ function calculatePrediction(prediction, result, competition, matches) {
     });
   }
 
-  const addPointsAndPicks = (thisRoundScoring) => {
-    points.playoff = {
-      points: points.playoff.points + thisRoundScoring.points,
-      correctPicks: points.playoff.correctPicks + 1,
-    };
-  };
   // playoff picks
   if (
     competition.scoring.playoff &&
@@ -74,10 +68,11 @@ function calculatePrediction(prediction, result, competition, matches) {
         // these picks were prepopulated
       } else {
         const thisRoundPredictions = prediction.playoffPredictions.filter(
-          (playoffPrediction) => playoffPrediction.round === playoffResult.round
+          (playoffPrediction) =>
+            playoffPrediction.round === playoffResult.round,
         );
         const thisRoundScoring = competition.scoring.playoff.find(
-          (c) => c.roundNumber === playoffResult.round
+          (c) => c.roundNumber === playoffResult.round,
         );
         if (thisRoundScoring && thisRoundPredictions) {
           // match the result against each team in prediction
@@ -85,9 +80,14 @@ function calculatePrediction(prediction, result, competition, matches) {
           // in multiple spots and getting points for each
           playoffResult.teams.forEach((t) => {
             const teamFound = thisRoundPredictions.find(
-              (p) => p.homeTeam === t || p.awayTeam === t
+              (p) => p.homeTeam === t || p.awayTeam === t,
             );
-            if (teamFound) addPointsAndPicks(thisRoundScoring);
+            if (teamFound) {
+              points.playoff = {
+                points: points.playoff.points + thisRoundScoring.points,
+                correctPicks: points.playoff.correctPicks + 1,
+              };
+            }
           });
         }
       }
@@ -131,111 +131,176 @@ function calculatePrediction(prediction, result, competition, matches) {
     points.champion.correctPicks +
     points.misc.correctPicks;
 
-  // find potential points possible
-  let potentialPoints;
+  const potentialPoints = calculatePotentialPoints(
+    prediction,
+    result,
+    competition,
+    tree,
+    final,
+    totalPoints,
+  );
+
+  // return {points, totalPoints, totalPicks} for bulkwrite
+  return { points, totalPoints, totalPicks, potentialPoints };
+}
+
+function buildBracketTree(matchNumber, matches) {
+  const match = matches.find((m) => m.matchNumber === matchNumber);
+  if (!match) return null;
+  const node = { match };
+  if (match.getTeamsFrom) {
+    node.left = buildBracketTree(match.getTeamsFrom.home.matchNumber, matches);
+    node.right = buildBracketTree(match.getTeamsFrom.away.matchNumber, matches);
+  }
+  return node;
+}
+
+function findNodeByMatchNumber(node, matchNumber) {
+  if (!node) return null;
+  if (node.match.matchNumber === matchNumber) return node;
+  return (
+    findNodeByMatchNumber(node.left, matchNumber) ||
+    findNodeByMatchNumber(node.right, matchNumber)
+  );
+}
+
+function getTeamsInSubtree(node, remainingTeams) {
+  if (!node) return [];
+  if (!node.match.getTeamsFrom) {
+    return [node.match.homeTeamName, node.match.awayTeamName].filter((t) =>
+      remainingTeams.includes(t),
+    );
+  }
+  return [
+    ...getTeamsInSubtree(node.left, remainingTeams),
+    ...getTeamsInSubtree(node.right, remainingTeams),
+  ];
+}
+
+function calculatePotentialPoints(
+  prediction,
+  result,
+  competition,
+  tree,
+  final,
+  totalPoints,
+) {
   let maximum = totalPoints;
   let realistic = totalPoints;
-  const remainingTeams = result.playoff[result.playoff.length - 1].teams;
-  // if the final round has been entered in the results document then there are no more potential points to calculate, set them to equal total points
-  if (
-    result.playoff &&
-    prediction?.playoffPredictions &&
-    result.playoff[result.playoff.length - 1] ===
-      prediction.playoffPredictions[prediction.playoffPredictions.length - 1]
-        ?.round
-  ) {
-    // do nothing, the competition is in the final round
+  /* 
+  if the final round has been entered in the results document
+  then there are no more potential points to calculate,
+  set them to equal total points
+  */
+  const latestResultRound = result.playoff?.length;
+  const finalCompetitionRound = competition.scoring.playoff?.length;
+  if (!latestResultRound) {
+    maximum = 0;
+    realistic = 0;
   } else if (
+    latestResultRound < finalCompetitionRound &&
     competition.scoring.playoff &&
     result.playoff &&
     prediction.playoffPredictions
   ) {
-    // get the remaining teams from the result (latest playoff stage entered)
-    // if the prediction picked a winner that is in the remaining teams then those points are possible (realistic)
+    /*
+    get the remaining teams from the result
+    (latest playoff stage entered)
+    if the prediction picked a winner that is in the remaining teams
+    then those points are possible (realistic)
+    */
+    const remainingTeams = result.playoff[result.playoff.length - 1]?.teams;
     if (remainingTeams.includes(prediction.misc?.winner)) {
       maximum += competition.scoring.champion;
       realistic += competition.scoring.champion;
     }
 
-    if (matches && matches.length > 0) {
-      // if matches were passed then we can figure out which playoff teams have potential to reach the next round
-      // must map backwards from final to see which teams are possible
-      let highestRound = 0;
-      let final;
-      matches.forEach((match) => {
-        if (highestRound < match.round) {
-          highestRound = match.round;
-          final = match;
+    if (tree && final) {
+      const completedRounds = new Set(result.playoff.map((r) => r.round));
+      let potentialPlayoffPoints = 0;
+
+      prediction.playoffPredictions.forEach((pred) => {
+        if (completedRounds.has(pred.round)) return;
+
+        const thisRoundPoints =
+          competition.scoring.playoff.find((c) => c.roundNumber === pred.round)
+            ?.points || 0;
+
+        const node = findNodeByMatchNumber(tree, pred.matchNumber);
+        if (!node || !node.left || !node.right) return;
+
+        const leftTeams = getTeamsInSubtree(node.left, remainingTeams);
+        const rightTeams = getTeamsInSubtree(node.right, remainingTeams);
+
+        const homeInLeft = leftTeams.includes(pred.homeTeam);
+        const homeInRight = rightTeams.includes(pred.homeTeam);
+        const awayInLeft = leftTeams.includes(pred.awayTeam);
+        const awayInRight = rightTeams.includes(pred.awayTeam);
+
+        const homeReachable = homeInLeft || homeInRight;
+        const awayReachable = awayInLeft || awayInRight;
+
+        if (homeReachable) potentialPlayoffPoints += thisRoundPoints;
+        if (awayReachable) potentialPlayoffPoints += thisRoundPoints;
+
+        // if both teams are reachable but their paths collide in the same
+        // subtree, one is guaranteed to eliminate the other before this round
+        if (homeReachable && awayReachable) {
+          const collision =
+            (homeInLeft && awayInLeft) || (homeInRight && awayInRight);
+          if (collision) potentialPlayoffPoints -= thisRoundPoints;
         }
       });
-      if (final) {
-        // give finalist points to each semi final containing a finalist
-        const thisRoundPoints =
-          competition.scoring.playoff.find((c) => c.roundNumber === final.round)
-            ?.points || 0;
-        let finalistPoints = 0;
-        prediction.playoffPredictions.forEach((m) => {
-          if (m.round === final.round) {
-            const finalists = [m.homeTeam, m.awayTeam];
-            if (remainingTeams.includes(m.homeTeam)) {
-              finalistPoints += thisRoundPoints;
-            }
-            if (remainingTeams.includes(m.awayTeam)) {
-              finalistPoints += thisRoundPoints;
-            }
-            const previousMatchResult1 = matches.find(
-              (m) => m.matchNumber === final.getTeamsFrom.home.matchNumber
-            );
-            const previousMatchResult2 = matches.find(
-              (m) => m.matchNumber === final.getTeamsFrom.away.matchNumber
-            );
-            if (
-              finalists.includes(previousMatchResult1.homeTeamName) &&
-              finalists.includes(previousMatchResult1.awayTeamName)
-            )
-              finalistPoints -= thisRoundPoints;
-            if (
-              finalists.includes(previousMatchResult2.homeTeamName) &&
-              finalists.includes(previousMatchResult2.awayTeamName)
-            )
-              finalistPoints -= thisRoundPoints;
-          }
-        });
-        maximum += finalistPoints;
-        realistic += finalistPoints;
+
+      maximum += potentialPlayoffPoints;
+      realistic += potentialPlayoffPoints;
+
+      // thirdPlace potential: a team can finish third if they lose in the semi-final
+      // check if the prediction's thirdPlace pick is predicted for the semi-final
+      // and is still a remaining team
+      const thirdPlaceMiscPick = competition.miscPicks?.find(
+        (m) => m.name === "thirdPlace",
+      );
+      const thirdPlacePick = prediction.misc?.thirdPlace;
+      if (thirdPlaceMiscPick && thirdPlacePick) {
+        const semiFinalPredictions = prediction.playoffPredictions.filter(
+          (m) => m.round === final.round - 1,
+        );
+        const isThirdPlaceCandidate =
+          remainingTeams.includes(thirdPlacePick) &&
+          semiFinalPredictions.some(
+            (m) =>
+              m.homeTeam === thirdPlacePick || m.awayTeam === thirdPlacePick,
+          );
+        if (isThirdPlaceCandidate) {
+          maximum += thirdPlaceMiscPick.points;
+          realistic += thirdPlaceMiscPick.points;
+        }
       }
     }
-    // if the prediction picked a miscPick that is in the remaining teams then those points are available but not realistic
-    // for third place they are not available
-    // if the miscPick is contained in the "realisticWinners" entry within the result then those points should be added to both
+    // if the prediction picked a miscPick that is in the remaining teams
+    // then those points are available but not yet realistic
+    // if the miscPick is contained in the "realisticWinners" entry
+    // within the result then those points should be added to realistic as well
     if (competition.miscPicks && result.misc && prediction.misc) {
       competition.miscPicks.forEach((miscPick) => {
-        const realisticWinners =
-          (result.potentials?.realisticWinners &&
-            result.potentials?.realisticWinners[miscPick.name]) ||
-          [];
-        const predictionPick = prediction.misc[miscPick.name];
+        if (miscPick.name !== "thirdPlace") {
+          const realisticWinners =
+            (result.potentials?.realisticWinners &&
+              result.potentials?.realisticWinners[miscPick.name]) ||
+            [];
+          const predictionPick = prediction.misc[miscPick.name];
 
-        if (
-          remainingTeams.includes(predictionPick) &&
-          miscPick.name !== "thirdPlace"
-        )
-          maximum += miscPick.points;
-        if (realisticWinners.includes(predictionPick)) {
-          realistic += miscPick.points;
-          if (miscPick.name === "thirdPlace") maximum += miscPick.points;
+          if (remainingTeams.includes(predictionPick))
+            maximum += miscPick.points;
+          if (realisticWinners.includes(predictionPick))
+            realistic += miscPick.points;
         }
       });
     }
   }
 
-  potentialPoints = {
-    maximum,
-    realistic,
-  };
-
-  // return {points, totalPoints, totalPicks} for bulkwrite
-  return { points, totalPoints, totalPicks, potentialPoints };
+  return { maximum, realistic };
 }
 
 function getDescendantProp(obj, desc) {
@@ -290,3 +355,4 @@ function addRanking(predictions) {
 
 module.exports.calculatePrediction = calculatePrediction;
 module.exports.addRanking = addRanking;
+module.exports.buildBracketTree = buildBracketTree;


### PR DESCRIPTION
Extract calculatePotentialPoints into its own function, build the bracket tree once at the competition level rather than per-prediction, and replace the final-only potential points logic with a general binary tree traversal that detects path collisions at any depth across all future rounds. Also add thirdPlace semi-finalist potential points logic and data-driven test cases covering collision/no-collision scenarios through QF stage.