### PR TITLE
add team elimination lookup feature for leaderboard

### DIFF
--- a/__test__/integration/migrations/backfillTeamEliminations.test.js
+++ b/__test__/integration/migrations/backfillTeamEliminations.test.js
@@ -1,0 +1,121 @@
+const mongoose = require("mongoose");
+const { Prediction } = require("../../../models/prediction.model");
+const { Competition } = require("../../../models/competition.model");
+const { backfillTeamEliminations } = require("../../../scripts/migrations/backfillTeamEliminations");
+const { predictions, competitions } = require("../../testData");
+const { deleteAllData, cleanup } = require("../../helperFunctions");
+const { start } = require("../../..");
+
+let server;
+
+describe("backfillTeamEliminations migration", () => {
+  beforeAll(async () => {
+    if (process.env.NODE_ENV === "test") {
+      server = await start();
+    } else throw "Not in test environment";
+  });
+  afterAll(async () => {
+    await cleanup(server);
+  });
+  afterEach(async () => {
+    await deleteAllData();
+  });
+
+  it("should backfill teamEliminations on predictions that are missing it", async () => {
+    const competitionID = mongoose.Types.ObjectId();
+    await Competition.collection.insertOne({
+      ...competitions[0],
+      _id: competitionID,
+    });
+    await Prediction.collection.insertOne({
+      ...predictions[1],
+      _id: mongoose.Types.ObjectId(),
+      competitionID,
+    });
+
+    await backfillTeamEliminations();
+
+    const updated = await Prediction.findOne({ competitionID });
+    expect(updated.teamEliminations).toBeDefined();
+    expect(updated.teamEliminations["Denmark"]).toBe("Winner");
+    expect(updated.teamEliminations["Argentina"]).toBe("Runner-Up");
+    expect(updated.teamEliminations["Brazil"]).toBe("Group Stage");
+  });
+
+  it("should not overwrite predictions that already have teamEliminations", async () => {
+    const competitionID = mongoose.Types.ObjectId();
+    await Competition.collection.insertOne({
+      ...competitions[0],
+      _id: competitionID,
+    });
+    const existing = { France: "Winner" };
+    await Prediction.collection.insertOne({
+      ...predictions[1],
+      _id: mongoose.Types.ObjectId(),
+      competitionID,
+      teamEliminations: existing,
+    });
+
+    await backfillTeamEliminations();
+
+    const unchanged = await Prediction.findOne({ competitionID });
+    expect(unchanged.teamEliminations["France"]).toBe("Winner");
+    expect(unchanged.teamEliminations["Denmark"]).toBeUndefined();
+  });
+
+  it("should skip predictions whose competition has no scoring.playoff", async () => {
+    const competitionID = mongoose.Types.ObjectId();
+    await Competition.collection.insertOne({
+      ...competitions[1],
+      _id: competitionID,
+    });
+    await Prediction.collection.insertOne({
+      ...predictions[1],
+      _id: mongoose.Types.ObjectId(),
+      competitionID,
+    });
+
+    await backfillTeamEliminations();
+
+    const unchanged = await Prediction.findOne({ competitionID });
+    expect(unchanged.teamEliminations).toBeUndefined();
+  });
+
+  it("should skip predictions whose competition does not exist", async () => {
+    await Prediction.collection.insertOne({
+      ...predictions[1],
+      _id: mongoose.Types.ObjectId(),
+      competitionID: mongoose.Types.ObjectId(),
+    });
+
+    await backfillTeamEliminations();
+
+    const unchanged = await Prediction.findOne({
+      teamEliminations: { $exists: false },
+    });
+    expect(unchanged).not.toBeNull();
+  });
+
+  it("should process multiple predictions across multiple competitions efficiently", async () => {
+    const competitionID1 = mongoose.Types.ObjectId();
+    const competitionID2 = mongoose.Types.ObjectId();
+    await Competition.collection.insertMany([
+      { ...competitions[0], _id: competitionID1, code: "comp1" },
+      { ...competitions[0], _id: competitionID2, code: "comp2" },
+    ]);
+    await Prediction.collection.insertMany([
+      { ...predictions[1], _id: mongoose.Types.ObjectId(), competitionID: competitionID1 },
+      { ...predictions[1], _id: mongoose.Types.ObjectId(), competitionID: competitionID1 },
+      { ...predictions[1], _id: mongoose.Types.ObjectId(), competitionID: competitionID2 },
+    ]);
+
+    await backfillTeamEliminations();
+
+    const all = await Prediction.find({});
+    expect(all).toHaveLength(3);
+    all.forEach((p) => {
+      expect(p.teamEliminations).toBeDefined();
+      expect(p.teamEliminations["Denmark"]).toBe("Winner");
+    });
+  });
+});

--- a/__test__/integration/routes/prediction.route.test.js
+++ b/__test__/integration/routes/prediction.route.test.js
@@ -121,6 +121,23 @@ describe("predictionsRoute", () => {
       const insertedPrediction = await Prediction.findById(res.body);
       expect(insertedPrediction).not.toBeNull();
     });
+    it("should compute teamEliminations on create", async () => {
+      await raiseInsertCompetition(1);
+      const body = {
+        ...predictions[1],
+        competitionID,
+        userID,
+        name: "Eliminations Test",
+      };
+      const res = await exec(getToken(userID), body);
+      expect(res.status).toBe(200);
+      const saved = await Prediction.findById(res.body);
+      expect(saved.teamEliminations).toBeDefined();
+      expect(saved.teamEliminations["Denmark"]).toBe("Winner");
+      expect(saved.teamEliminations["Argentina"]).toBe("Runner-Up");
+      expect(saved.teamEliminations["Germany"]).toBe("Semi Final");
+      expect(saved.teamEliminations["Brazil"]).toBe("Group Stage");
+    });
     it("should include the second chance flag", async () => {
       await insertCompetition(competitionID, null, {
         secondChance: {
@@ -142,7 +159,12 @@ describe("predictionsRoute", () => {
       const res = await exec(getToken(), {
         ...prediction,
         isSecondChance: true,
-        misc: { winner: "Brazil", thirdPlace: "Argentina", discipline: "France", topScorer: "England" },
+        misc: {
+          winner: "Brazil",
+          thirdPlace: "Argentina",
+          discipline: "France",
+          topScorer: "England",
+        },
       });
       expect(res.status).toBe(200);
       const saved = await Prediction.findById(res.body);
@@ -246,15 +268,41 @@ describe("predictionsRoute", () => {
       );
       expect(updatedPrediction.name).toBe("Updated Name");
     });
+    it("should recompute teamEliminations on update", async () => {
+      await raiseInsertCompetition(1);
+      const inserted = await insertPrediction({ competitionID, userID });
+      const updateBody = {
+        ...predictions[1],
+        competitionID,
+        userID,
+        name: inserted.name,
+      };
+      const res = await exec(getToken(userID), inserted._id, updateBody);
+      expect(res.status).toBe(200);
+      const saved = await Prediction.findById(inserted._id);
+      expect(saved.teamEliminations).toBeDefined();
+      expect(saved.teamEliminations["Denmark"]).toBe("Winner");
+      expect(saved.teamEliminations["Argentina"]).toBe("Runner-Up");
+      expect(saved.teamEliminations["Brazil"]).toBe("Group Stage");
+    });
     it("should strip groupPredictions and non-winner/thirdPlace misc from second chance prediction on update", async () => {
       await insertCompetition(competitionID, null, {
         secondChance: { submissionDeadline: pickADate(1) },
       });
-      const inserted = await insertPrediction({ competitionID, userID, isSecondChance: true });
+      const inserted = await insertPrediction({
+        competitionID,
+        userID,
+        isSecondChance: true,
+      });
       const updateBody = {
         ...inserted,
         competitionID,
-        misc: { winner: "Brazil", thirdPlace: "Argentina", discipline: "France", topScorer: "England" },
+        misc: {
+          winner: "Brazil",
+          thirdPlace: "Argentina",
+          discipline: "France",
+          topScorer: "England",
+        },
         groupPredictions: [{ groupName: "A", teamOrder: ["a", "b", "c", "d"] }],
       };
       delete updateBody._id;
@@ -776,6 +824,87 @@ describe("predictionsRoute", () => {
       const res = await exec(getToken(userID), competitionID);
       expect(res.status).toBe(200);
       expect(res.body.length).toBe(insertedPredictions.length);
+    });
+  });
+
+  describe("GET /leaderboard/:id/eliminations/:team", () => {
+    const exec = async (competitionID, team = "Denmark", query = "") =>
+      await request(server).get(
+        `${endpoint}/leaderboard/${competitionID}/eliminations/${team}${query}`,
+      );
+    testObjectID(exec);
+    it("should return 404 if competition not found", async () => {
+      const res = await exec(mongoose.Types.ObjectId());
+      expect(res.status).toBe(404);
+      testResponseText(res.text, "competition not found");
+    });
+    it("should return 400 if submission deadline has not passed", async () => {
+      await raiseInsertCompetition(1);
+      const res = await exec(competitionID);
+      testReponse(res, 400, "hidden until submission deadline");
+    });
+    it("should return eliminationRound for each submission", async () => {
+      await raiseInsertCompetition(-1);
+      await Prediction.collection.insertOne({
+        ...predictions[1],
+        _id: mongoose.Types.ObjectId(),
+        competitionID,
+        userID,
+        teamEliminations: { Denmark: "Winner", Argentina: "Runner-Up" },
+      });
+      const res = await exec(competitionID, "Denmark");
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].eliminationRound).toBe("Winner");
+      expect(res.body[0].name).toBeDefined();
+    });
+    it("should return null eliminationRound for predictions without teamEliminations", async () => {
+      await raiseInsertCompetition(-1);
+      await Prediction.collection.insertOne({
+        ...predictions[1],
+        _id: mongoose.Types.ObjectId(),
+        competitionID,
+      });
+      const res = await exec(competitionID, "Denmark");
+      expect(res.status).toBe(200);
+      expect(res.body[0].eliminationRound).toBeNull();
+    });
+    it("should return null eliminationRound for a team not in a submission's teamEliminations", async () => {
+      await raiseInsertCompetition(-1);
+      await Prediction.collection.insertOne({
+        ...predictions[1],
+        _id: mongoose.Types.ObjectId(),
+        competitionID,
+        teamEliminations: { Denmark: "Winner" },
+      });
+      const res = await exec(competitionID, "Brazil");
+      expect(res.status).toBe(200);
+      expect(res.body[0].eliminationRound).toBeNull();
+    });
+    it("should return only second chance entries when queried", async () => {
+      await insertCompetition(competitionID, {
+        ...competitions[0],
+        submissionDeadline: pickADate(-1),
+        secondChance: { submissionDeadline: pickADate(-1) },
+      });
+      await Prediction.collection.insertOne({
+        ...predictions[1],
+        _id: mongoose.Types.ObjectId(),
+        competitionID,
+        isSecondChance: true,
+        teamEliminations: { Denmark: "Winner" },
+      });
+      await Prediction.collection.insertOne({
+        ...predictions[1],
+        _id: mongoose.Types.ObjectId(),
+        competitionID,
+        isSecondChance: false,
+        teamEliminations: { Denmark: "Semi Final" },
+      });
+      const res = await exec(competitionID, "Denmark", "?secondChance=true");
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].eliminationRound).toBe("Winner");
     });
   });
 

--- a/__test__/unit/utils/predictions.test.js
+++ b/__test__/unit/utils/predictions.test.js
@@ -1,0 +1,157 @@
+const { computeTeamEliminations } = require("../../../utils/predictions");
+const { predictions, competitions } = require("../../testData");
+
+// competitions[0] has rounds: 1=Round of 16, 2=Quarter Final, 3=Semi Final, 4=Final
+const competition = competitions[0];
+
+describe("computeTeamEliminations", () => {
+  describe("with a fully filled-out bracket", () => {
+    // predictions[1]: misc.winner = "Denmark", no thirdPlace
+    // Argentina and Denmark in round 4; Germany/Uruguay in round 3; etc.
+    const prediction = predictions[1];
+    let result;
+    beforeAll(() => {
+      result = computeTeamEliminations(prediction, competition);
+    });
+
+    it("should label the champion as Winner", () => {
+      expect(result["Denmark"]).toBe("Winner");
+    });
+
+    it("should label the runner-up correctly", () => {
+      expect(result["Argentina"]).toBe("Runner-Up");
+    });
+
+    it("should label semi-final exits correctly", () => {
+      expect(result["Germany"]).toBe("Semi Final");
+      expect(result["Uruguay"]).toBe("Semi Final");
+    });
+
+    it("should label quarter-final exits correctly", () => {
+      expect(result["Senegal"]).toBe("Quarter Final");
+      expect(result["Netherlands"]).toBe("Quarter Final");
+      expect(result["South Korea"]).toBe("Quarter Final");
+    });
+
+    it("should label round of 16 exits correctly", () => {
+      expect(result["IR Iran"]).toBe("Round of 16");
+      expect(result["Tunisia"]).toBe("Round of 16");
+      expect(result["Saudi Arabia"]).toBe("Round of 16");
+      expect(result["England"]).toBe("Round of 16");
+      expect(result["Croatia"]).toBe("Round of 16");
+      expect(result["Switzerland"]).toBe("Round of 16");
+      expect(result["Morocco"]).toBe("Round of 16");
+      expect(result["Japan"]).toBe("Round of 16");
+      expect(result["Cameroon"]).toBe("Round of 16");
+    });
+
+    it("should label group stage exits correctly", () => {
+      expect(result["Qatar"]).toBe("Group Stage");
+      expect(result["Ecuador"]).toBe("Group Stage");
+      expect(result["Brazil"]).toBe("Group Stage");
+      expect(result["Serbia"]).toBe("Group Stage");
+      expect(result["Portugal"]).toBe("Group Stage");
+      expect(result["Ghana"]).toBe("Group Stage");
+    });
+  });
+
+  describe("with a bracket that has placeholder picks", () => {
+    // predictions[0]: only round 1 has real teams; rounds 2+ are all "Winner X" placeholders
+    const prediction = predictions[0];
+    let result;
+    beforeAll(() => {
+      result = computeTeamEliminations(prediction, competition);
+    });
+
+    it("should label round 1 teams correctly", () => {
+      expect(result["Senegal"]).toBe("Round of 16");
+      expect(result["Argentina"]).toBe("Round of 16");
+      expect(result["Germany"]).toBe("Round of 16");
+    });
+
+    it("should not create entries for placeholder strings", () => {
+      const keys = Object.keys(result);
+      expect(keys.some((k) => k.startsWith("Winner"))).toBe(false);
+    });
+
+    it("should label all teams not in round 1 as Group Stage", () => {
+      expect(result["Qatar"]).toBe("Group Stage");
+      expect(result["Brazil"]).toBe("Group Stage");
+    });
+  });
+
+  describe("with a third place pick", () => {
+    const prediction = {
+      groupPredictions: [
+        { groupName: "A", teamOrder: ["BRA", "GER", "ARG", "FRA"] },
+      ],
+      playoffPredictions: [
+        { matchNumber: 1, homeTeam: "BRA", awayTeam: "GER", round: 1 },
+        { matchNumber: 2, homeTeam: "ARG", awayTeam: "FRA", round: 1 },
+        { matchNumber: 3, homeTeam: "BRA", awayTeam: "ARG", round: 2 },
+        { matchNumber: 4, homeTeam: "GER", awayTeam: "FRA", round: 2 },
+        { matchNumber: 5, homeTeam: "BRA", awayTeam: "GER", round: 3 },
+      ],
+      misc: { winner: "BRA", thirdPlace: "FRA" },
+    };
+    const minimalCompetition = {
+      scoring: {
+        playoff: [
+          { roundNumber: 1, roundName: "Quarter Final", points: 2 },
+          { roundNumber: 2, roundName: "Semi Final", points: 4 },
+          { roundNumber: 3, roundName: "Final", points: 8 },
+        ],
+      },
+    };
+    let result;
+    beforeAll(() => {
+      result = computeTeamEliminations(prediction, minimalCompetition);
+    });
+
+    it("should label the winner correctly", () => {
+      expect(result["BRA"]).toBe("Winner");
+    });
+
+    it("should label the runner-up correctly", () => {
+      expect(result["GER"]).toBe("Runner-Up");
+    });
+
+    it("should override the third place team's label", () => {
+      expect(result["FRA"]).toBe("Third Place");
+    });
+
+    it("should label the fourth place team with their last playoff round", () => {
+      expect(result["ARG"]).toBe("Semi Final");
+    });
+  });
+
+  describe("with empty or missing picks", () => {
+    it("should return an empty object when both pick arrays are empty", () => {
+      const prediction = { groupPredictions: [], playoffPredictions: [], misc: {} };
+      const result = computeTeamEliminations(prediction, competition);
+      expect(result).toEqual({});
+    });
+
+    it("should handle missing playoffPredictions gracefully", () => {
+      const prediction = {
+        groupPredictions: [{ groupName: "A", teamOrder: ["BRA", "GER"] }],
+        misc: {},
+      };
+      const result = computeTeamEliminations(prediction, competition);
+      expect(result["BRA"]).toBe("Group Stage");
+      expect(result["GER"]).toBe("Group Stage");
+    });
+
+    it("should handle missing groupPredictions gracefully", () => {
+      const prediction = {
+        playoffPredictions: [
+          { matchNumber: 1, homeTeam: "BRA", awayTeam: "GER", round: 1 },
+        ],
+        misc: {},
+      };
+      const result = computeTeamEliminations(prediction, competition);
+      expect(result["BRA"]).toBe("Round of 16");
+      expect(result["GER"]).toBe("Round of 16");
+    });
+  });
+});

--- a/models/prediction.model.js
+++ b/models/prediction.model.js
@@ -99,6 +99,7 @@ const predictionMongooseSchema = new mongoose.Schema({
       ],
     },
   ],
+  teamEliminations: { type: Object, required: false },
 });
 
 predictionMongooseSchema.index({ userID: 1, competitionID: 1 });

--- a/routes/controllers/leaderboard.controller.js
+++ b/routes/controllers/leaderboard.controller.js
@@ -10,7 +10,8 @@ const { Prediction } = require("../../models/prediction.model");
 
 async function getLeaderboardByGroup(req, res, next) {
   const competition = await Competition.findById(req.params.id);
-  if (!competition) return next({ status: 404, message: "Competition not found" });
+  if (!competition)
+    return next({ status: 404, message: "Competition not found" });
 
   let selectedFields =
     "name points totalPoints totalPicks ranking userID potentialPoints";
@@ -163,6 +164,51 @@ async function getNonUserPrediction(req, res, next) {
   res.send(predictionToSend);
 }
 
+async function getTeamEliminations(req, res, next) {
+  const competition = await Competition.findById(req.params.id);
+  if (!competition)
+    return next({ status: 404, message: "Competition not found" });
+
+  if (!deadlineHasPassed(competition, req.query.secondChance === "true"))
+    return next({
+      status: 400,
+      message: "Pick information hidden until submission deadline has passed",
+    });
+
+  const secondChanceQuery = {
+    isSecondChance: req.query.secondChance === "true" || { $ne: true },
+  };
+
+  const team = req.params.team;
+
+  const predictions = await Prediction.aggregate([
+    {
+      $match: {
+        competitionID: mongoose.Types.ObjectId(req.params.id),
+        ...secondChanceQuery,
+      },
+    },
+    {
+      $lookup: {
+        from: "users",
+        localField: "userID",
+        foreignField: "_id",
+        as: "user",
+      },
+    },
+    { $unwind: { path: "$user", preserveNullAndEmptyArrays: true } },
+    {
+      $project: {
+        name: 1,
+        userID: { name: "$user.name" },
+        eliminationRound: { $ifNull: [`$teamEliminations.${team}`, null] },
+      },
+    },
+  ]);
+
+  res.send(predictions);
+}
+
 async function getPredictionsByMisc(req, res, next) {
   const predictions = await Prediction.find({
     competitionID: req.params.id,
@@ -185,4 +231,5 @@ module.exports = {
   searchLeaderboard,
   getNonUserPrediction,
   getPredictionsByMisc,
+  getTeamEliminations,
 };

--- a/routes/controllers/prediction.controller.js
+++ b/routes/controllers/prediction.controller.js
@@ -9,6 +9,7 @@ const {
   deadlineHasPassed,
   addPoints,
   removePoints,
+  computeTeamEliminations,
 } = require("../../utils/predictions");
 
 function sanitizeSecondChancePrediction(body) {
@@ -87,6 +88,8 @@ async function createNewPrediction(req, res, next) {
 
   if (req.body.isSecondChance) sanitizeSecondChancePrediction(req.body);
 
+  req.body.teamEliminations = computeTeamEliminations(req.body, competition);
+
   const newPrediction = new Prediction(req.body);
   await newPrediction.save();
 
@@ -142,6 +145,8 @@ async function updatePrediction(req, res, next) {
   removePoints(req);
 
   if (prediction.isSecondChance) sanitizeSecondChancePrediction(req.body);
+
+  req.body.teamEliminations = computeTeamEliminations(req.body, competition);
 
   await Prediction.updateOne({ _id: req.params.id }, { $set: req.body });
 

--- a/routes/routers/prediction.route.js
+++ b/routes/routers/prediction.route.js
@@ -18,6 +18,7 @@ const {
   searchLeaderboard,
   getNonUserPrediction,
   getPredictionsByMisc,
+  getTeamEliminations,
 } = require("../controllers/leaderboard.controller");
 
 router.post("/", [auth], createNewPrediction);
@@ -25,6 +26,11 @@ router.put("/:id", [auth, validateObjectID], updatePrediction);
 router.get("/:id", [auth, validateObjectID], getPrediction);
 router.get("/", [auth], getUsersPredictions);
 router.delete("/:id", [auth, validateObjectID], deletePrediction);
+router.get(
+  "/leaderboard/:id/eliminations/:team",
+  [validateObjectID],
+  getTeamEliminations,
+);
 router.get(
   "/leaderboard/:id/:resultsPerPage/:pageNumber/:groupID",
   [validateObjectID],

--- a/scripts/migrations/backfillTeamEliminations.js
+++ b/scripts/migrations/backfillTeamEliminations.js
@@ -1,0 +1,45 @@
+const { Prediction } = require("../../models/prediction.model");
+const { Competition } = require("../../models/competition.model");
+const { computeTeamEliminations } = require("../../utils/predictions");
+
+async function backfillTeamEliminations() {
+  const predictions = await Prediction.find({
+    teamEliminations: { $exists: false },
+  });
+
+  console.log(`Found ${predictions.length} predictions to backfill.`);
+  if (predictions.length === 0) return;
+
+  const competitionCache = {};
+  let updated = 0;
+  let skipped = 0;
+
+  for (const prediction of predictions) {
+    const compId = String(prediction.competitionID);
+    if (!competitionCache[compId]) {
+      competitionCache[compId] = await Competition.findById(compId);
+    }
+    const competition = competitionCache[compId];
+
+    if (!competition?.scoring?.playoff?.length) {
+      skipped++;
+      continue;
+    }
+
+    const teamEliminations = computeTeamEliminations(prediction, competition);
+    await Prediction.updateOne(
+      { _id: prediction._id },
+      { $set: { teamEliminations } },
+    );
+    updated++;
+  }
+
+  console.log(`Done. Updated: ${updated}, skipped: ${skipped}.`);
+}
+
+module.exports = { backfillTeamEliminations };
+
+if (require.main === module) {
+  const { runMigration } = require("./migrationSetup");
+  runMigration(backfillTeamEliminations);
+}

--- a/scripts/migrations/migrationSetup.js
+++ b/scripts/migrations/migrationSetup.js
@@ -1,0 +1,16 @@
+const mongoose = require("mongoose");
+
+require("../../startup/db")(process.env.NODE_ENV);
+
+async function runMigration(migrationFn) {
+  try {
+    await migrationFn();
+  } catch (err) {
+    console.error("Migration failed:", err);
+    process.exit(1);
+  } finally {
+    await mongoose.connection.close();
+  }
+}
+
+module.exports = { runMigration };

--- a/utils/predictions.js
+++ b/utils/predictions.js
@@ -44,9 +44,57 @@ function removePoints(req) {
   delete req.body.potentialPoints;
 }
 
+function computeTeamEliminations(prediction, competition) {
+  const { groupPredictions, playoffPredictions, misc } = prediction;
+  const { scoring } = competition;
+
+  const roundMap = {};
+  let finalRound = 0;
+  for (const r of scoring.playoff) {
+    roundMap[r.roundNumber] = r.roundName;
+    if (r.roundNumber > finalRound) finalRound = r.roundNumber;
+  }
+
+  const teamHighestRound = {};
+  for (const match of playoffPredictions || []) {
+    for (const team of [match.homeTeam, match.awayTeam]) {
+      if (!team || team.startsWith("Winner")) continue;
+      if (!teamHighestRound[team] || match.round > teamHighestRound[team]) {
+        teamHighestRound[team] = match.round;
+      }
+    }
+  }
+
+  const eliminations = {};
+  const playoffTeams = new Set(Object.keys(teamHighestRound));
+
+  for (const [team, highestRound] of Object.entries(teamHighestRound)) {
+    if (highestRound === finalRound) {
+      eliminations[team] = misc?.winner === team ? "Winner" : "Runner-Up";
+    } else {
+      eliminations[team] = roundMap[highestRound] || `Round ${highestRound}`;
+    }
+  }
+
+  if (misc?.thirdPlace && eliminations[misc.thirdPlace] !== undefined) {
+    eliminations[misc.thirdPlace] = "Third Place";
+  }
+
+  for (const group of groupPredictions || []) {
+    for (const team of group.teamOrder || []) {
+      if (!playoffTeams.has(team)) {
+        eliminations[team] = "Group Stage";
+      }
+    }
+  }
+
+  return eliminations;
+}
+
 module.exports = {
   deadlineHasPassed,
   leaderboardFilters,
   addPoints,
   removePoints,
+  computeTeamEliminations,
 };


### PR DESCRIPTION
Adds the ability to look up, for any team in a competition, at what round each submission predicted that team to be eliminated. This allows users to quickly scan all brackets for a team's fate without opening each one individually.

Core logic:
- computeTeamEliminations(prediction, competition) in utils/predictions.js derives a { teamName: roundLabel } map from a prediction's playoffPredictions and groupPredictions. Skips "Winner X" placeholder entries (partial brackets), applies winner/runner-up/third place labels from misc, and falls back to "Group Stage" for teams not appearing in any playoff match.

Model:
- Added teamEliminations: { type: Object } field to the Prediction schema.

Save/update:
- computeTeamEliminations is called on both create and update in prediction.controller.js, after Joi validation and after sanitizeSecondChancePrediction, so the stored map always reflects the sanitized picks.

Read endpoint:
- GET /api/v1/predictions/leaderboard/:competitionID/eliminations/:team returns an array of { _id, name, userID: { name }, eliminationRound } for all submissions in the competition. Uses aggregation to project only the requested team's value from teamEliminations rather than fetching the full map for every prediction. Gated behind the submission deadline. Supports ?secondChance=true query param. Returns null for eliminationRound on predictions that predate this feature (pre-migration).

Migration:
- scripts/migrations/backfillTeamEliminations.js backfills teamEliminations on all existing predictions that are missing the field. Caches competition lookups by ID, skips predictions whose competition has no scoring.playoff, and is idempotent (safe to re-run). Run via Render shell: node scripts/migrations/backfillTeamEliminations.js
- scripts/migrations/migrationSetup.js provides standardized DB connect, error handling, and disconnect for all future migration scripts.

Tests:
- 16 unit tests for computeTeamEliminations covering all elimination outcomes, placeholder bracket handling, third place, and edge cases.
- 2 integration tests on POST / and PUT /:id confirming teamEliminations is written on create and recomputed on update.
- 7 integration tests on the new GET eliminations endpoint.
- 5 integration tests for the migration script itself.