### PR TITLE
support partial playoff rounds in potential points calculation

### DIFF
--- a/__test__/unit/utils/calculations.test.js
+++ b/__test__/unit/utils/calculations.test.js
@@ -3,6 +3,7 @@ const {
   calculatePrediction,
   addRanking,
   buildBracketTree,
+  getRemainingTeamsFromTree,
 } = require("../../../utils/calculations");
 const {
   predictions,
@@ -32,13 +33,17 @@ describe("calculations", () => {
     const exec = (prediction, result, competition, matches) => {
       let tree = null;
       let final = null;
+      let remainingTeams = null;
       if (matches && matches.length > 0) {
         matches.forEach((match) => {
           if (!final || match.round > final.round) final = match;
         });
-        if (final) tree = buildBracketTree(final.matchNumber, matches);
+        if (final) {
+          tree = buildBracketTree(final.matchNumber, matches);
+          remainingTeams = getRemainingTeamsFromTree(tree);
+        }
       }
-      return calculatePrediction(prediction, result, competition, tree, final);
+      return calculatePrediction(prediction, result, competition, tree, final, remainingTeams);
     };
 
     const setPrediction = (
@@ -457,6 +462,13 @@ describe("calculations", () => {
           playoff: [{ round: 1, teams: ["a", "b", "c", "d"] }],
           misc: { topScorer: "", discipline: "" },
         };
+        // All matches unaccepted so a, b, c, d are all in remainingTeams.
+        // Playoff predictions use non-matching teams (x/y) so totalPoints = 0.
+        const matches = [
+          { matchNumber: 1, homeTeamName: "a", awayTeamName: "b", round: 1, matchAccepted: false },
+          { matchNumber: 2, homeTeamName: "c", awayTeamName: "d", round: 1, matchAccepted: false },
+          { matchNumber: 3, homeTeamName: "Winner 1", awayTeamName: "Winner 2", round: 2, matchAccepted: false, getTeamsFrom: { home: { matchNumber: 1 }, away: { matchNumber: 2 } } },
+        ];
 
         // Use non-matching teams so totalPoints = 0, making expected values predictable
         const playoffPreds = [
@@ -476,7 +488,7 @@ describe("calculations", () => {
             topScorer: "a",
             discipline: "b",
           });
-          const res = exec(prediction, result, competition);
+          const res = exec(prediction, result, competition, matches);
           expect(res.potentialPoints.realistic).toBe(10);
         });
 
@@ -491,7 +503,7 @@ describe("calculations", () => {
             topScorer: "a",
             discipline: "b",
           });
-          const res = exec(prediction, result, competition);
+          const res = exec(prediction, result, competition, matches);
           expect(res.potentialPoints.realistic).toBe(0);
         });
 
@@ -507,7 +519,7 @@ describe("calculations", () => {
             topScorer: "a",
             discipline: "b",
           });
-          const res = exec(prediction, result, competition);
+          const res = exec(prediction, result, competition, matches);
           expect(res.potentialPoints.realistic).toBe(20);
         });
 
@@ -517,7 +529,7 @@ describe("calculations", () => {
             topScorer: "a",
             discipline: "b",
           });
-          const res = exec(prediction, result, competition);
+          const res = exec(prediction, result, competition, matches);
           expect(res.potentialPoints.realistic).toBe(0);
         });
 
@@ -527,7 +539,7 @@ describe("calculations", () => {
             topScorer: "a",
             discipline: "b",
           });
-          const res = exec(prediction, result, competition);
+          const res = exec(prediction, result, competition, matches);
           expect(res.potentialPoints.realistic).toBe(0);
         });
       });
@@ -614,12 +626,20 @@ describe("calculations", () => {
         ], { winner: "a", thirdPlace: "b", discipline: "a", topScorer: "a" });
         prediction.isSecondChance = true;
 
-        const res = exec(prediction, partialResult, twoRoundCompetition);
+        // Round 1 accepted — "b" (thirdPlace pick) is eliminated and not in remainingTeams.
+        // Round 2 unaccepted with real winners — "a" is remaining for champion potential.
+        const res = exec(prediction, partialResult, twoRoundCompetition, [
+          { matchNumber: 1, homeTeamName: "a", awayTeamName: "b", round: 1, matchAccepted: true },
+          { matchNumber: 2, homeTeamName: "c", awayTeamName: "d", round: 1, matchAccepted: true },
+          { matchNumber: 3, homeTeamName: "a", awayTeamName: "c", round: 2, matchAccepted: false, getTeamsFrom: { home: { matchNumber: 1 }, away: { matchNumber: 2 } } },
+        ]);
 
-        // winner "a" still in remaining teams → champion potential
+        // winner "a" still in remaining teams → champion +32
+        // "a" and "c" both reachable to the final (opposite subtrees, no collision) → playoff +8
+        // thirdPlace "b" was eliminated in round 1 → not in remaining → no thirdPlace potential
         // discipline and topScorer picks should NOT add potential points for second chance
-        expect(res.potentialPoints.maximum).toBe(32);
-        expect(res.potentialPoints.realistic).toBe(32);
+        expect(res.potentialPoints.maximum).toBe(40);
+        expect(res.potentialPoints.realistic).toBe(40);
       });
     });
   });
@@ -682,6 +702,24 @@ describe("calculations", () => {
       expect(tree.left.right.match.matchNumber).toBe(2);
       expect(tree.right.left.match.matchNumber).toBe(3);
       expect(tree.right.right.match.matchNumber).toBe(4);
+    });
+    it("should use metadata.matchNumber for lookup when present", () => {
+      const metadataMatches = [
+        { matchNumber: 101, metadata: { matchNumber: 1 }, homeTeamName: "A", awayTeamName: "B", round: 1 },
+        { matchNumber: 102, metadata: { matchNumber: 2 }, homeTeamName: "C", awayTeamName: "D", round: 1 },
+        {
+          matchNumber: 103,
+          metadata: { matchNumber: 3 },
+          homeTeamName: "Winner 1",
+          awayTeamName: "Winner 2",
+          round: 2,
+          getTeamsFrom: { home: { matchNumber: 1 }, away: { matchNumber: 2 } },
+        },
+      ];
+      const tree = buildBracketTree(3, metadataMatches);
+      expect(tree.match.matchNumber).toBe(103);
+      expect(tree.left.match.matchNumber).toBe(101);
+      expect(tree.right.match.matchNumber).toBe(102);
     });
   });
 

--- a/routes/controllers/result.controller.js
+++ b/routes/controllers/result.controller.js
@@ -3,6 +3,7 @@ const {
   calculatePrediction,
   addRanking,
   buildBracketTree,
+  getRemainingTeamsFromTree,
 } = require("../../utils/calculations");
 const { calculateWhatIfPaths } = require("../../utils/whatIf");
 
@@ -26,11 +27,12 @@ const calculateAndPostSubmissions = async (competition, result) => {
     if (!final || match.round > final.round) final = match;
   });
   if (final) tree = buildBracketTree(final.matchNumber, matches);
+  const remainingTeams = tree ? getRemainingTeamsFromTree(tree) : null;
 
   let updatedPoints = [];
   allPredictions.forEach((p) => {
     const { points, totalPoints, totalPicks, potentialPoints } =
-      calculatePrediction(p, result, competition, tree, final);
+      calculatePrediction(p, result, competition, tree, final, remainingTeams);
     updatedPoints.push({
       _id: p._id,
       isSecondChance: p.isSecondChance,

--- a/test_data/potentialPointsCases.js
+++ b/test_data/potentialPointsCases.js
@@ -28,13 +28,14 @@ const defaultResult = {
 
 // Two-match bracket feeding into a final at round 2
 const defaultMatches = [
-  { matchNumber: 1, homeTeamName: "a", awayTeamName: "b", round: 1 },
-  { matchNumber: 2, homeTeamName: "c", awayTeamName: "d", round: 1 },
+  { matchNumber: 1, homeTeamName: "a", awayTeamName: "b", round: 1, matchAccepted: false },
+  { matchNumber: 2, homeTeamName: "c", awayTeamName: "d", round: 1, matchAccepted: false },
   {
     matchNumber: 3,
     homeTeamName: "Winner 1",
     awayTeamName: "Winner 2",
     round: 2,
+    matchAccepted: false,
     getTeamsFrom: { home: { matchNumber: 1 }, away: { matchNumber: 2 } },
   },
 ];
@@ -56,15 +57,16 @@ const qfCompetition = {
   },
 };
 const qfMatches = [
-  { matchNumber: 1, homeTeamName: "A", awayTeamName: "B", round: 1 },
-  { matchNumber: 2, homeTeamName: "C", awayTeamName: "D", round: 1 },
-  { matchNumber: 3, homeTeamName: "E", awayTeamName: "F", round: 1 },
-  { matchNumber: 4, homeTeamName: "G", awayTeamName: "H", round: 1 },
+  { matchNumber: 1, homeTeamName: "A", awayTeamName: "B", round: 1, matchAccepted: false },
+  { matchNumber: 2, homeTeamName: "C", awayTeamName: "D", round: 1, matchAccepted: false },
+  { matchNumber: 3, homeTeamName: "E", awayTeamName: "F", round: 1, matchAccepted: false },
+  { matchNumber: 4, homeTeamName: "G", awayTeamName: "H", round: 1, matchAccepted: false },
   {
     matchNumber: 5,
     homeTeamName: "Winner 1",
     awayTeamName: "Winner 2",
     round: 2,
+    matchAccepted: false,
     getTeamsFrom: { home: { matchNumber: 1 }, away: { matchNumber: 2 } },
   },
   {
@@ -72,6 +74,7 @@ const qfMatches = [
     homeTeamName: "Winner 3",
     awayTeamName: "Winner 4",
     round: 2,
+    matchAccepted: false,
     getTeamsFrom: { home: { matchNumber: 3 }, away: { matchNumber: 4 } },
   },
   {
@@ -79,6 +82,7 @@ const qfMatches = [
     homeTeamName: "Winner 5",
     awayTeamName: "Winner 6",
     round: 3,
+    matchAccepted: false,
     getTeamsFrom: { home: { matchNumber: 5 }, away: { matchNumber: 6 } },
   },
 ];
@@ -92,6 +96,7 @@ const groupFedMatches = [
     homeTeamName: "Brazil",
     awayTeamName: "Spain",
     round: 1,
+    matchAccepted: false,
     type: "Playoff",
     getTeamsFrom: { home: { groupName: "A", position: 1 }, away: { groupName: "B", position: 2 } },
   },
@@ -100,6 +105,7 @@ const groupFedMatches = [
     homeTeamName: "Argentina",
     awayTeamName: "France",
     round: 1,
+    matchAccepted: false,
     type: "Playoff",
     getTeamsFrom: { home: { groupName: "B", position: 1 }, away: { groupName: "A", position: 2 } },
   },
@@ -108,6 +114,7 @@ const groupFedMatches = [
     homeTeamName: "Winner 1",
     awayTeamName: "Winner 2",
     round: 2,
+    matchAccepted: false,
     type: "Playoff",
     getTeamsFrom: { home: { matchNumber: 1 }, away: { matchNumber: 2 } },
   },
@@ -189,7 +196,7 @@ const potentialPointsTestCases = [
       },
       result: defaultResult,
       competition: defaultCompetition,
-      matches: [],
+      matches: defaultMatches,
     },
     expected: {
       totalPoints: 8,
@@ -205,11 +212,11 @@ const potentialPointsTestCases = [
           { matchNumber: 1, homeTeam: "c", awayTeam: "d", round: 1 },
           { matchNumber: 1, homeTeam: "a", awayTeam: "c", round: 2 },
         ],
-        misc: { topScorer: "b", discipline: "c", thirdPlace: "c" },
+        misc: { topScorer: "b", discipline: "c" },
       },
       result: defaultResult,
       competition: defaultCompetition,
-      matches: [],
+      matches: defaultMatches,
     },
     expected: {
       totalPoints: 8,
@@ -363,4 +370,240 @@ const potentialPointsTestCases = [
   },
 ];
 
-module.exports = potentialPointsTestCases;
+// 4-QF partial round: QF1 (A/B) and QF2 (C/D) accepted, QF3 (E/F) and QF4 (G/H) not.
+// SF1 team names updated to real winners (A, C); SF2 still has placeholders.
+const partialQfMatches = [
+  { matchNumber: 1, homeTeamName: "A", awayTeamName: "B", round: 1, matchAccepted: true },
+  { matchNumber: 2, homeTeamName: "C", awayTeamName: "D", round: 1, matchAccepted: true },
+  { matchNumber: 3, homeTeamName: "E", awayTeamName: "F", round: 1, matchAccepted: false },
+  { matchNumber: 4, homeTeamName: "G", awayTeamName: "H", round: 1, matchAccepted: false },
+  {
+    matchNumber: 5,
+    homeTeamName: "A",
+    awayTeamName: "C",
+    round: 2,
+    matchAccepted: false,
+    getTeamsFrom: { home: { matchNumber: 1 }, away: { matchNumber: 2 } },
+  },
+  {
+    matchNumber: 6,
+    homeTeamName: "Winner 3",
+    awayTeamName: "Winner 4",
+    round: 2,
+    matchAccepted: false,
+    getTeamsFrom: { home: { matchNumber: 3 }, away: { matchNumber: 4 } },
+  },
+  {
+    matchNumber: 7,
+    homeTeamName: "Winner 5",
+    awayTeamName: "Winner 6",
+    round: 3,
+    matchAccepted: false,
+    getTeamsFrom: { home: { matchNumber: 5 }, away: { matchNumber: 6 } },
+  },
+];
+const partialQfResult = {
+  playoff: [{ round: 1, teams: ["A", "C"] }],
+  misc: {},
+};
+const partialQfCompetition = {
+  scoring: {
+    playoff: [
+      { roundNumber: 1, points: 2 },
+      { roundNumber: 2, points: 4 },
+      { roundNumber: 3, points: 8 },
+    ],
+    champion: 16,
+  },
+  miscPicks: [],
+};
+
+// Partial-round test fixtures
+// SF1 (match 1) is complete — A won. SF2 (match 2) is not yet played.
+// The final (match 3) has homeTeamName updated to "A" (the known winner).
+const partialRoundMatches = [
+  { matchNumber: 1, homeTeamName: "A", awayTeamName: "B", round: 1, matchAccepted: true },
+  { matchNumber: 2, homeTeamName: "C", awayTeamName: "D", round: 1, matchAccepted: false },
+  {
+    matchNumber: 3,
+    homeTeamName: "A",
+    awayTeamName: "Winner 2",
+    round: 2,
+    matchAccepted: false,
+    getTeamsFrom: { home: { matchNumber: 1 }, away: { matchNumber: 2 } },
+  },
+];
+const partialRoundResult = {
+  playoff: [{ round: 1, teams: ["A"] }],
+  misc: {},
+};
+const partialRoundCompetition = {
+  scoring: {
+    playoff: [
+      { roundNumber: 1, points: 4 },
+      { roundNumber: 2, points: 8 },
+    ],
+    champion: 16,
+  },
+  miscPicks: [],
+};
+
+const partialRoundWithThirdPlaceCompetition = {
+  scoring: {
+    playoff: [
+      { roundNumber: 1, points: 4 },
+      { roundNumber: 2, points: 8 },
+    ],
+    champion: 16,
+  },
+  miscPicks: [{ name: "thirdPlace", points: 16 }],
+};
+
+const partialRoundTestCases = [
+  {
+    description:
+      "ThirdPlace pick adds no points if the pick already won their semi (finalist cannot finish third)",
+    data: {
+      prediction: {
+        playoffPredictions: [
+          { matchNumber: 1, homeTeam: "A", awayTeam: "B", round: 1 },
+          { matchNumber: 3, homeTeam: "A", awayTeam: "C", round: 2 },
+        ],
+        misc: { thirdPlace: "A" },
+      },
+      result: partialRoundResult,
+      competition: partialRoundWithThirdPlaceCompetition,
+      matches: partialRoundMatches,
+    },
+    expected: {
+      totalPoints: 4,
+      // A won SF1 → match 1 accepted → skipped for potential
+      // A is in remainingTeams (via unaccepted final) but their SF match is accepted → not a thirdPlace candidate
+      // match 3: A reachable from left (+8), C reachable from right (+8), no collision → +16
+      potentialPoints: { maximum: 20, realistic: 20 },
+    },
+  },
+  {
+    description: "Partial QF round — SF prediction earns points for both known winners from opposite accepted QFs",
+    data: {
+      prediction: {
+        playoffPredictions: [{ matchNumber: 5, homeTeam: "A", awayTeam: "C", round: 2 }],
+      },
+      result: partialQfResult,
+      competition: partialQfCompetition,
+      matches: partialQfMatches,
+    },
+    expected: {
+      totalPoints: 0,
+      // A reachable from left subtree (QF1 leaf, A in remaining), C from right (QF2 leaf, C in remaining)
+      // no collision (opposite subtrees) → +4 each
+      potentialPoints: { maximum: 8, realistic: 8 },
+    },
+  },
+  {
+    description: "Partial QF round — final prediction with teams from opposite bracket halves earns full points",
+    data: {
+      prediction: {
+        playoffPredictions: [{ matchNumber: 7, homeTeam: "A", awayTeam: "E", round: 3 }],
+      },
+      result: partialQfResult,
+      competition: partialQfCompetition,
+      matches: partialQfMatches,
+    },
+    expected: {
+      totalPoints: 0,
+      // A reachable from SF1 subtree (left half), E reachable from SF2 subtree (right half)
+      // no collision → +8 each
+      potentialPoints: { maximum: 16, realistic: 16 },
+    },
+  },
+  {
+    description: "Partial QF round — final prediction with both teams from accepted QF half collides",
+    data: {
+      prediction: {
+        playoffPredictions: [{ matchNumber: 7, homeTeam: "A", awayTeam: "C", round: 3 }],
+      },
+      result: partialQfResult,
+      competition: partialQfCompetition,
+      matches: partialQfMatches,
+    },
+    expected: {
+      totalPoints: 0,
+      // A and C both feed into SF1 (left half of final) → collision → +8 +8 -8 = 8
+      potentialPoints: { maximum: 8, realistic: 8 },
+    },
+  },
+
+  {
+    description: "Partial round — prediction for accepted match is skipped, unplayed match earns potential",
+    data: {
+      prediction: {
+        playoffPredictions: [
+          { matchNumber: 1, homeTeam: "A", awayTeam: "B", round: 1 },
+          { matchNumber: 2, homeTeam: "C", awayTeam: "D", round: 1 },
+          { matchNumber: 3, homeTeam: "A", awayTeam: "C", round: 2 },
+        ],
+      },
+      result: partialRoundResult,
+      competition: partialRoundCompetition,
+      matches: partialRoundMatches,
+    },
+    expected: {
+      totalPoints: 4,
+      // match 1 accepted → skipped; match 2 is a leaf → skipped by !left||!right guard
+      // match 3: A is reachable from left subtree (match 1 leaf, A in remainingTeams);
+      //          C is reachable from right subtree (match 2 leaf) → +8 each, no collision
+      potentialPoints: { maximum: 20, realistic: 20 },
+    },
+  },
+  {
+    description: "Partial round — winner pick on a remaining team still earns champion potential",
+    data: {
+      prediction: {
+        playoffPredictions: [
+          { matchNumber: 3, homeTeam: "A", awayTeam: "C", round: 2 },
+        ],
+        misc: { winner: "C" },
+      },
+      result: partialRoundResult,
+      competition: partialRoundCompetition,
+      matches: partialRoundMatches,
+    },
+    expected: {
+      totalPoints: 0,
+      // C is remaining → champion +16; final pick A+C both reachable from opposite sides → +8 each
+      potentialPoints: { maximum: 32, realistic: 32 },
+    },
+  },
+  {
+    description: "All matches accepted — remainingTeams is empty, no potential added",
+    data: {
+      prediction: {
+        playoffPredictions: [
+          { matchNumber: 3, homeTeam: "A", awayTeam: "C", round: 2 },
+        ],
+        misc: { winner: "A" },
+      },
+      result: { playoff: [{ round: 1, teams: ["A"] }, { round: 2, teams: ["A"] }], misc: {} },
+      competition: partialRoundCompetition,
+      matches: [
+        { matchNumber: 1, homeTeamName: "A", awayTeamName: "B", round: 1, matchAccepted: true },
+        { matchNumber: 2, homeTeamName: "C", awayTeamName: "D", round: 1, matchAccepted: true },
+        {
+          matchNumber: 3,
+          homeTeamName: "A",
+          awayTeamName: "C",
+          round: 2,
+          matchAccepted: true,
+          getTeamsFrom: { home: { matchNumber: 1 }, away: { matchNumber: 2 } },
+        },
+      ],
+    },
+    expected: {
+      totalPoints: 8,
+      potentialPoints: { maximum: 8, realistic: 8 },
+    },
+  },
+];
+
+module.exports = [...potentialPointsTestCases, ...partialRoundTestCases];

--- a/utils/calculations.js
+++ b/utils/calculations.js
@@ -1,4 +1,4 @@
-function calculatePrediction(prediction, result, competition, tree, final) {
+function calculatePrediction(prediction, result, competition, tree, final, remainingTeams) {
   let points = {
     group: { points: 0, correctPicks: 0, bonus: 0 },
     playoff: { points: 0, correctPicks: 0 },
@@ -138,6 +138,7 @@ function calculatePrediction(prediction, result, competition, tree, final) {
     tree,
     final,
     totalPoints,
+    remainingTeams,
   );
 
   // return {points, totalPoints, totalPicks} for bulkwrite
@@ -171,13 +172,29 @@ function getTeamsInSubtree(node, remainingTeams) {
   if (!node) return [];
   if (!node.left && !node.right) {
     return [node.match.homeTeamName, node.match.awayTeamName].filter((t) =>
-      remainingTeams.includes(t),
+      remainingTeams.has(t),
     );
   }
   return [
     ...getTeamsInSubtree(node.left, remainingTeams),
     ...getTeamsInSubtree(node.right, remainingTeams),
   ];
+}
+
+function getRemainingTeamsFromTree(node) {
+  const teams = new Set();
+  const stack = [node];
+  while (stack.length) {
+    const n = stack.pop();
+    if (!n) continue;
+    if (!n.match.matchAccepted) {
+      teams.add(n.match.homeTeamName);
+      teams.add(n.match.awayTeamName);
+    }
+    if (n.left) stack.push(n.left);
+    if (n.right) stack.push(n.right);
+  }
+  return teams;
 }
 
 function calculatePotentialPoints(
@@ -187,51 +204,39 @@ function calculatePotentialPoints(
   tree,
   final,
   totalPoints,
+  remainingTeams,
 ) {
   let maximum = totalPoints;
   let realistic = totalPoints;
-  /* 
-  if the final round has been entered in the results document
-  then there are no more potential points to calculate,
-  set them to equal total points
-  */
+
   const latestResultRound = result.playoff?.length;
-  const finalCompetitionRound = competition.scoring.playoff?.length;
 
   if (!latestResultRound) {
     maximum = 0;
     realistic = 0;
   } else if (
-    latestResultRound < finalCompetitionRound &&
+    remainingTeams?.size > 0 &&
     competition.scoring.playoff &&
     result.playoff &&
     prediction.playoffPredictions
   ) {
-    /*
-    get the remaining teams from the result
-    (latest playoff stage entered)
-    if the prediction picked a winner that is in the remaining teams
-    then those points are possible (realistic)
-    */
-    const remainingTeams = result.playoff[result.playoff.length - 1]?.teams;
-    if (remainingTeams.includes(prediction.misc?.winner)) {
+    if (remainingTeams.has(prediction.misc?.winner)) {
       maximum += competition.scoring.champion;
       realistic += competition.scoring.champion;
     }
 
     if (tree && final) {
-      const completedRounds = new Set(result.playoff.map((r) => r.round));
       let potentialPlayoffPoints = 0;
 
       prediction.playoffPredictions.forEach((pred) => {
-        if (completedRounds.has(pred.round)) return;
+        const node = findNodeByMatchNumber(tree, pred.matchNumber);
+        if (!node) return;
+        if (node.match.matchAccepted) return;
+        if (!node.left || !node.right) return;
 
         const thisRoundPoints =
           competition.scoring.playoff.find((c) => c.roundNumber === pred.round)
             ?.points || 0;
-
-        const node = findNodeByMatchNumber(tree, pred.matchNumber);
-        if (!node || !node.left || !node.right) return;
 
         const leftTeams = getTeamsInSubtree(node.left, remainingTeams);
         const rightTeams = getTeamsInSubtree(node.right, remainingTeams);
@@ -271,17 +276,20 @@ function calculatePotentialPoints(
           (m) => m.round === final.round - 1,
         );
         const isThirdPlaceCandidate =
-          remainingTeams.includes(thirdPlacePick) &&
-          semiFinalPredictions.some(
-            (m) =>
-              m.homeTeam === thirdPlacePick || m.awayTeam === thirdPlacePick,
-          );
+          remainingTeams.has(thirdPlacePick) &&
+          semiFinalPredictions.some((m) => {
+            if (m.homeTeam !== thirdPlacePick && m.awayTeam !== thirdPlacePick)
+              return false;
+            const sfNode = findNodeByMatchNumber(tree, m.matchNumber);
+            return sfNode && !sfNode.match.matchAccepted;
+          });
         if (isThirdPlaceCandidate) {
           maximum += thirdPlaceMiscPick.points;
           realistic += thirdPlaceMiscPick.points;
         }
       }
     }
+
     // if the prediction picked a miscPick that is in the remaining teams
     // then those points are available but not yet realistic
     // if the miscPick is contained in the "realisticWinners" entry
@@ -295,8 +303,7 @@ function calculatePotentialPoints(
               ?.leaders?.map((l) => l.team) || [];
           const predictionPick = prediction.misc[miscPick.name];
 
-          if (remainingTeams.includes(predictionPick))
-            maximum += miscPick.points;
+          if (remainingTeams.has(predictionPick)) maximum += miscPick.points;
           if (realisticWinners.includes(predictionPick))
             realistic += miscPick.points;
         }
@@ -360,3 +367,4 @@ function addRanking(predictions) {
 module.exports.calculatePrediction = calculatePrediction;
 module.exports.addRanking = addRanking;
 module.exports.buildBracketTree = buildBracketTree;
+module.exports.getRemainingTeamsFromTree = getRemainingTeamsFromTree;


### PR DESCRIPTION
Remaining teams are now derived from the bracket tree (matchAccepted: false matches) rather than from result.playoff, so partially completed rounds are handled correctly. getRemainingTeamsFromTree is built once per calculation batch in the controller and passed down, replacing the per-prediction completedRounds Set with a per-match matchAccepted check.